### PR TITLE
Add update identity feature

### DIFF
--- a/config-default.inc.php
+++ b/config-default.inc.php
@@ -79,5 +79,15 @@ $rcmail_config['ldapAliasSync'] = array(
         # Domain parts to ignore in attr_mail (optional)
         'attr_mail_ignore' => array(),
     ),
+
+    # Update identity
+    # Set to true if you want update the identity in the database
+    # if it's already exist (with the same email) (Default : False)
+    'update_identity' => false,
+
+    # Update only nonempty fields of the identity
+    # Set to true if you want to update only nonempty fields of the
+    # identity. (Default : True)
+    'update_only_nonempty_fields' => true
 );
 ?>

--- a/ldapAliasSync.php
+++ b/ldapAliasSync.php
@@ -275,6 +275,16 @@ class ldapAliasSync extends rcube_plugin {
                             foreach ( $db_identities as $db_identity ) {
                                 # email is our only comparison parameter
                                 if( $db_identity['email'] == $identity['email'] ) {
+                                    if (isset($this -> config['update_identity']) && $this -> config['update_identity']) {
+                                        if (!isset($this -> config['update_only_nonempty_fields']) || $this -> config['update_only_nonempty_fields']) {
+                                            foreach ($identity as $key => $value) {
+                                                if (empty($identity[$key])) unset($identity[$key]);
+                                            }
+                                        }
+                                        $this->rc_user->update_identity ( $db_identity['identity_id'], $identity );
+                                        $log = "Updated identity: ".$identity['email'];
+                                    }
+                                    write_log('ldapAliasSync', $log);
                                     $in_db = true;
                                     break;
                                 }


### PR DESCRIPTION
I need to update identity to keep it synchronize with LDAP informations. So I develop this feature and create two boolean configuration parameter to control it :
 - update_identity to enable or disable update (false by default)
 - update_only_nonempty_fields to avoid erase user's input informations when this fields could not be found in LDAP

Thank's