### PR TITLE
Update ldapAliasSync.php

### DIFF
--- a/ldapAliasSync.php
+++ b/ldapAliasSync.php
@@ -234,7 +234,7 @@ class ldapAliasSync extends rcube_plugin {
                             if ( strstr($email, '@') ) {
                                 # Verify that domain part is not ignored
                                 $domain = explode('@', $email)[1];
-                                if ( in_array($domain, $this->attr_mail_ignore) ) continue;
+                                if ( is_array($this->attr_mail_ignore) and in_array($domain, $this->attr_mail_ignore) ) continue;
 
                                 if ( !$name )         $name         = '';
                                 if ( !$organisation ) $organisation = '';


### PR DESCRIPTION
Add a control on Line 237 to prevent PHP Warning relative to  "$this->attr_mail_ignore"  :

PHP Warning:  in_array() expects parameter 2 to be array, null given in /usr/share/roundcubemail/plugins/ldapAliasSync/ldapAliasSync.php on line 246