### PR TITLE
Added simple composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "dim-0/ldapAliasSync",
+    "type": "roundcube-plugin",
+    "license": "GPLv3",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://plugins.roundcube.net"
+        }
+    ],
+    "require": {
+        "roundcube/plugin-installer": ">=0.1.3"
+    }
+}


### PR DESCRIPTION
This composer.json will allow people to include the plugin with composer even if it is not in officially in plugins.roundcube.net