### PR TITLE
Roundcube 1.3.0 compatibility and LDAP URI alternative configuration parameter

### DIFF
--- a/config-default.inc.php
+++ b/config-default.inc.php
@@ -40,6 +40,12 @@ $rcmail_config['ldapAliasSync'] = array(
 		# Default: 'localhost'
 		#'server' => 'localhost',
 
+		# LDAP server URI (optional)
+		# You could also directly specify LDAP URI of your server(s). Multiple LDAP URI
+		# could be specify separated by space.
+		# Default: False
+		#'uri'    => false,
+
 		# LDAP server port (optional)
 		# Default: '389'
 		#'port' => '389',

--- a/ldapAliasSync.php
+++ b/ldapAliasSync.php
@@ -101,7 +101,12 @@ class ldapAliasSync extends rcube_plugin {
 		$uri = '';
 		$con = null;
 
-		$uri = $config['scheme'].'://'.$config['server'].':'.$config['port'];
+		if (isset($config['uri']) && $config['uri']) {
+			$uri = $config['uri'];
+		}
+		else {
+			$uri = $config['scheme'].'://'.$config['server'].':'.$config['port'];
+		}
 
 		$con = ldap_connect($uri);
 

--- a/ldapAliasSync.php
+++ b/ldapAliasSync.php
@@ -472,24 +472,24 @@ class ldapAliasSync extends rcube_plugin {
 	}
 
 	function log_error($msg) {
-		write_log('ldapAliasSync', "ERROR: ".$msg);
+		rcmail::write_log('ldapAliasSync', "ERROR: ".$msg);
 	}
 
 	function log_warning($msg) {
 		if ( $this->cfg_general['log_level'] >= 1 ) {
-			write_log('ldapAliasSync', "WARNING: ".$msg);
+			rcmail::write_log('ldapAliasSync', "WARNING: ".$msg);
 		}
 	}
 
 	function log_info($msg) {
 		if ( $this->cfg_general['log_level'] >= 2 ) {
-			write_log('ldapAliasSync', "INFO: ".$msg);
+			rcmail::write_log('ldapAliasSync', "INFO: ".$msg);
 		}
 	}
 
 	function log_debug($msg) {
 		if ( $this->cfg_general['log_level'] >= 3 ) {
-			write_log('ldapAliasSync', "DEBUG: ".$msg);
+			rcmail::write_log('ldapAliasSync', "DEBUG: ".$msg);
 		}
 	}
 


### PR DESCRIPTION
Hello,

I fix Roundcube 1.3.0 compatibility by fixing _write_log()_ call and I add LDAP URI alternative configuration parameter : This parameter could be use instead of LDAP scheme and server parameters. It's also permit to define multiple LDAP servers URI (backup server(s)).